### PR TITLE
A small bug fix for average mode icon

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -48,7 +48,13 @@ function getTheWeatherData(city) {
       index.temp = Math.round(dataAverage(index.temp) - 273.15); /* C*/
       index.humidity = Math.round(dataAverage(index.humidity)); /* % */
       index.wind = dataAverage(index.wind).toFixed(2); /* %km/h*/
-      index.icon = getMode(index.icon);
+      // Accounts for night time. Filters out night time data, displaying the average day time.
+      if (index.icon.length === 8) {
+        index.icon = getMode(index.icon.slice(2, 6));
+      } else {
+        index.icon = index.icon;
+        index.icon = getMode(index.icon);
+      }
     });
     displayData(dateObjects, city); /* displays the data to the html page* */
     saveToLocalStorage(city); /*saves the city to local storage */


### PR DESCRIPTION
A small bug, I noticed when displaying the icons.     I saw that the average day icon was for clear skies. This is not what most users want when they are checking the forecast. they normally want an average day forecast.        
I fixed it, by adding if the `iconArray. length === 8` (the whole day) only send in the data for between 6am and 9pm. And get an average from that. Else(it is less the 8), meaning it is the current day, being displayed, display the average for that day. 